### PR TITLE
Use strings.TrimSuffix instead of strings.Trim

### DIFF
--- a/pkg/httpapi/api.go
+++ b/pkg/httpapi/api.go
@@ -184,7 +184,7 @@ func parseURL(s string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse %#v: %w", s, err)
 	}
-	return strings.TrimLeft(strings.Trim(parsed.Path, ".git"), "/"), nil
+	return strings.TrimLeft(strings.TrimSuffix(parsed.Path, ".git"), "/"), nil
 }
 
 func secretRefFromQuery(v url.Values) (types.NamespacedName, bool) {

--- a/pkg/httpapi/api_test.go
+++ b/pkg/httpapi/api_test.go
@@ -267,8 +267,9 @@ func TestParseURL(t *testing.T) {
 		wantRepo string
 		wantErr  string
 	}{
-		{"https://github.com/example/gitops.git", "example/gitops", ""},
+		{"https://github.com/example/gitops.git?ref=main", "example/gitops", ""},
 		{"%%foo.html", "", "invalid URL escape"},
+		{"https://github.com/example/testing.git", "example/testing", ""},
 	}
 
 	for _, tt := range urlTests {


### PR DESCRIPTION
strings.Trim() removes the Unicode points present in the input cutset instead of trimming the entire matched string