### PR TITLE
Openshift-ci needs OWNERS at the root of the repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- sbose78
+- wtam2018
+- bigkevmcd
+- chetan-rns
+- amitkrout
+
+reviewers:
+- sbose78
+- wtam2018
+- bigkevmcd
+- chetan-rns
+- keithchong
+- amitkrout
+- dewan-ahmed


### PR DESCRIPTION
Creating OWNERS file since openshift-ci needs such at the root of the repo