### PR TITLE
Adding skeleton test scripts for openshift/release PR

### DIFF
--- a/scripts/openshiftci-presubmit-all-tests.sh
+++ b/scripts/openshiftci-presubmit-all-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+
+# Do not show token in CI log
+set +x
+
+# show commands
+set -x
+export CI="prow"
+go mod vendor
+
+export PATH="$PATH:$(pwd)"
+export ARTIFACTS_DIR="/tmp/artifacts"
+
+# Reference e2e test(s)
+echo "Please reference the E2E test script(s) here"

--- a/scripts/openshiftci-presubmit-unittests.sh
+++ b/scripts/openshiftci-presubmit-unittests.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+export ARTIFACTS_DIR="/tmp/artifacts"
+export CUSTOM_HOMEDIR=$ARTIFACTS_DIR
+export PATH=$PATH:$GOPATH/bin
+
+go env
+go mod vendor
+if [[ $(go fmt `go list ./... | grep -v vendor`) ]]; then
+    echo "not well formatted sources are found"
+    exit 1
+fi
+go mod tidy
+if [[ ! -z $(git status -s) ]]
+then
+    echo "Go mod state is not clean."
+    exit 1
+fi
+
+# Unit tests to be referenced here
+echo "Please reference the unit test script(s) here"


### PR DESCRIPTION
Adding these files since https://github.com/openshift/release/pull/16088 fails for not being able to find these under gitops-backend/scripts 