### PR TITLE
fix: update default ref from main to HEAD

### DIFF
--- a/pkg/httpapi/api.go
+++ b/pkg/httpapi/api.go
@@ -24,7 +24,7 @@ var DefaultSecretRef = types.NamespacedName{
 	Namespace: "pipelines-app-delivery",
 }
 
-const defaultRef = "main"
+const defaultRef = "HEAD"
 
 // APIRouter is an HTTP API for accessing app configurations.
 type APIRouter struct {

--- a/pkg/httpapi/api_test.go
+++ b/pkg/httpapi/api_test.go
@@ -27,7 +27,7 @@ const (
 
 func TestGetPipelines(t *testing.T) {
 	ts, c := makeServer(t)
-	c.addContents("example/gitops", "pipelines.yaml", "main", "testdata/pipelines.yaml")
+	c.addContents("example/gitops", "pipelines.yaml", "HEAD", "testdata/pipelines.yaml")
 	pipelinesURL := "https://github.com/example/gitops.git"
 
 	req := makeClientRequest(t, "Bearer testing", fmt.Sprintf("%s/pipelines?url=%s", ts.URL, pipelinesURL))
@@ -115,7 +115,7 @@ func TestGetPipelinesWithNamespaceAndNameInURL(t *testing.T) {
 	ts, c := makeServer(t, func(a *APIRouter) {
 		a.secretGetter = sg
 	})
-	c.addContents("example/gitops", "pipelines.yaml", "main", "testdata/pipelines.yaml")
+	c.addContents("example/gitops", "pipelines.yaml", "HEAD", "testdata/pipelines.yaml")
 	pipelinesURL := "https://github.com/example/gitops.git"
 	options := url.Values{
 		"url":        []string{pipelinesURL},
@@ -173,7 +173,7 @@ func TestGetPipelineApplication(t *testing.T) {
 	ts, c := makeServer(t, func(a *APIRouter) {
 		a.resourceParser = stubResourceParser(testResource)
 	})
-	c.addContents("example/gitops", "pipelines.yaml", "main", "testdata/pipelines.yaml")
+	c.addContents("example/gitops", "pipelines.yaml", "HEAD", "testdata/pipelines.yaml")
 	pipelinesURL := "https://github.com/example/gitops.git"
 	options := url.Values{
 		"url": []string{pipelinesURL},


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What does this PR do / why we need it**:

GitHub updated its default branch from master to main. But GitLab is still using master, due to which the GitOps UI APIs were failing for a GitLab repository. This PR updates the default ref to HEAD.

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-768

**How to test changes / Special notes to the reviewer**:
1. Install OpenShift GItOps operator
2. Build a custom backend image with this fix

```shell
docker build -t quay.io/<name>/gitops-backend .
docker push quay.io/<name>/gitops-backend
```
3. Replace this image in the `cluster` deployment resource in `openshift-gitops` namespace. This'll bring up new backend pods
4. Follow Day 1 and check if the Environments page gets populated for both GitHub and GitLab.