### PR TITLE
Feat: added API for updated Application details page

### DIFF
--- a/pkg/httpapi/conversion.go
+++ b/pkg/httpapi/conversion.go
@@ -39,7 +39,7 @@ func applicationsToAppsResponse(appSet []*argoV1aplha1.Application, repoURL stri
 
 	for _, app := range appSet {
 		if repoURL != strings.TrimSuffix(app.Spec.Source.RepoURL, ".git") {
-			log.Printf("repoURL[%v], doesn not match with Source Repo URL[%v]", repoURL, strings.TrimSuffix(app.Spec.Source.RepoURL, ".git"))
+			log.Printf("repoURL[%v], does not match with Source Repo URL[%v]", repoURL, strings.TrimSuffix(app.Spec.Source.RepoURL, ".git"))
 			continue
 		}
 		if app.ObjectMeta.Labels != nil {

--- a/pkg/httpapi/testdata/application.yaml
+++ b/pkg/httpapi/testdata/application.yaml
@@ -16,5 +16,6 @@ spec:
 status:
   history:
     - deployedAt: "2021-05-15T02:12:13Z"
+      revision: "123456789"
   sync:
     status: Synced


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This PR adds a new API which would be called by the Dev Console for the updated Application details page. 

Currently the server address for ArgoCD, is hardcoded to `openshift-gitops-server` since there is no easy way to determine which argocd instance gitops-backend-service is pointing to. Also, KAM currently is only supported with the `openshift-gitops` instance. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/GITOPS-577

**How to test changes / Special notes to the reviewer**:
TODO
