### PR TITLE
chore: Add go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/redhat-developer/gitops-backend
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.8
 
 require (
 	github.com/argoproj/argo-cd/v2 v2.14.11


### PR DESCRIPTION
**What type of PR is this?**
Konflux fails to build with error during prefetch stage
```
2025-07-28 04:11:36,803 ERROR The command "go env GOWORK" failed
2025-07-28 04:11:36,803 ERROR STDERR:
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
2025-07-28 04:11:36,809 ERROR PackageManagerError: Go execution failed: `go env GOWORK` failed with rc=1
Error: PackageManagerError: Go execution failed: `go env GOWORK` failed with rc=1
  The cause of the failure could be:
  - something is broken in Cachi2
  - something is wrong with your repository
  - communication with an external service failed (please try again)
  The output of the failing command should provide more details, please check the logs.
step-use-trusted-artifact :-
```



**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
